### PR TITLE
feat: add YouTube playlist support

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -124,6 +124,10 @@ a:hover { text-decoration: underline; }
 .notes[hidden] { display: none !important; }
 .notes textarea { width: 100%; min-height: 80px; padding: 8px; border-radius: 8px; border: 1px solid #d1d5db; font-family: inherit; font-size: 0.9rem; }
 
+.playlist-wrap { margin-top: 8px; }
+.playlist-wrap ol { margin: 4px 0 0 20px; padding: 0; }
+.playlist-wrap .start-playlist { margin-left: 8px; }
+
 /* Print */
 @media print {
   .hero, .toc, .toolbar, .progress-wrap { display: none !important; }

--- a/index.html
+++ b/index.html
@@ -58,6 +58,11 @@
           <select id="filter-channel" aria-label="Filter by channel">
             <option value="">All channels</option>
           </select>
+          <select id="filter-type" aria-label="Filter by type">
+            <option value="">All types</option>
+            <option value="video">Videos</option>
+            <option value="playlist">Playlists</option>
+          </select>
           <button id="filter-watchlist" type="button" aria-pressed="false" title="Show watchlist only">Watchlist</button>
           <button id="filter-watched" type="button" aria-pressed="false" title="Show watched">Watched</button>
         </div>


### PR DESCRIPTION
## Summary
- allow filtering by content type (videos vs playlists)
- detect YouTube playlists and list their videos on demand
- add basic styles for playlist listings

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --check assets/js/app.js`


------
https://chatgpt.com/codex/tasks/task_e_68b7e4314c0c8320bac94d2fd9b57f73