### PR TITLE
Handle missing data in YouTube playlist items

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -163,7 +163,13 @@
         const res = await fetch(api);
         if (!res.ok) throw new Error('HTTP '+res.status);
         const data = await res.json();
-        data.items.forEach(v => { videos.push({ title: v.snippet.title, id: v.snippet.resourceId.videoId }); });
+        data.items.forEach(v => {
+          const vid = v?.snippet?.resourceId?.videoId;
+          const title = v?.snippet?.title;
+          if (vid && title) {
+            videos.push({ title, id: vid });
+          }
+        });
         item.playlistCount = data.pageInfo?.totalResults || videos.length;
         token = data.nextPageToken;
       } while(token);


### PR DESCRIPTION
## Summary
- guard against YouTube playlist items without snippet or video id so playlists load correctly

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b7ea5e570883209cb59f34a26fc066